### PR TITLE
Use LispWorks-compatible Unicode char literal

### DIFF
--- a/src/buildnode.lisp
+++ b/src/buildnode.lisp
@@ -4,7 +4,7 @@
 ;;;;  Common string util, stoplen from adwutils
 (defparameter +common-white-space-trimbag+
   '(#\space #\newline #\return #\tab
-    #\u00A0 ;; this is #\no-break_space
+    #\u+00A0 ;; this is #\no-break_space
     ))
 
 (defun trim-whitespace (s)


### PR DESCRIPTION
LispWorks doesn't recognize #\u00a0, but does recognize #\u+00a0.  The latter form is also supported by at least ClozureCL and SBCL.