### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Buildnode: A libary to ease interaction with cxml:dom documents and nodes
+# Buildnode: A library to ease interaction with cxml:dom documents and nodes
 
 ## Examples 
 

--- a/README.md
+++ b/README.md
@@ -25,31 +25,8 @@ Please see the examples directory for runable examples in each XML dialect
   * [Nathan Bird](http://the.unwashedmeme.com/blog)
   * [Ryan Davis](http://ryepup.unwashedmeme.com/blog)
 
+## License
 
-```
-;; Copyright (c) 2011 Russ Tyndall , Acceleration.net http://www.acceleration.net
-;; All rights reserved.
-;;
-;; Redistribution and use in source and binary forms, with or without
-;; modification, are permitted provided that the following conditions are
-;; met:
-;;
-;;  - Redistributions of source code must retain the above copyright
-;;    notice, this list of conditions and the following disclaimer.
-;;
-;;  - Redistributions in binary form must reproduce the above copyright
-;;    notice, this list of conditions and the following disclaimer in the
-;;    documentation and/or other materials provided with the distribution.
-;;
-;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-;; "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-;; LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-;; A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
-;; OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-;; SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-;; LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-;; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-;; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-```
+For the licensing terms, please refer to the file named COPYING, located in the
+root directory of this library's source distribution.
+

--- a/buildnode-excel.asd
+++ b/buildnode-excel.asd
@@ -1,12 +1,5 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :net.acceleration.buildnode.system)
-    (defpackage :net.acceleration.buildnode.system
-	(:use :common-lisp :asdf))))
-
-(in-package :net.acceleration.buildnode.system)
-
 (defsystem :buildnode-excel
   :description "Tool for building up an xml dom of an excel spreadsheet nicely.
   Uses this XML format:
@@ -14,10 +7,9 @@
   "
   :components
   ((:module :src
-	    :serial T
-	    :components
-	    ((:module :tags
-		      :serial T
-		      :components
-		      ((:file "excel"))))))
+    :serial T
+    :components
+    ((:module :tags
+      :serial T
+      :components ((:file "excel"))))))
   :depends-on (:buildnode))

--- a/buildnode-excel.asd
+++ b/buildnode-excel.asd
@@ -5,6 +5,7 @@
   Uses this XML format:
   http://msdn.microsoft.com/en-us/library/aa140066%28office.10%29.aspx
   "
+  :licence "BSD-3-Clause"
   :components
   ((:module :src
     :serial T

--- a/buildnode-html5.asd
+++ b/buildnode-html5.asd
@@ -1,20 +1,12 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :net.acceleration.buildnode.system)
-    (defpackage :net.acceleration.buildnode.system
-	(:use :common-lisp :asdf))))
-
-(in-package :net.acceleration.buildnode.system)
-
 (defsystem :buildnode-html5
   :description "Tool for building up an xml dom of an html5 document"
   :components
   ((:module :src
-	    :serial T
-	    :components
-	    ((:module :tags
-		      :serial T
-		      :components
-		      ((:file "html5-tags"))))))
+    :serial T
+    :components
+    ((:module :tags
+      :serial T
+      :components ((:file "html5-tags"))))))
   :depends-on (:buildnode))

--- a/buildnode-html5.asd
+++ b/buildnode-html5.asd
@@ -2,6 +2,7 @@
 
 (defsystem :buildnode-html5
   :description "Tool for building up an xml dom of an html5 document"
+  :licence "BSD-3-Clause"
   :components
   ((:module :src
     :serial T

--- a/buildnode-kml.asd
+++ b/buildnode-kml.asd
@@ -2,6 +2,7 @@
 
 (defsystem :buildnode-kml
   :description "Tool for building up an xml dom of an KML."
+  :licence "BSD-3-Clause"
   :components
   ((:module :src
     :serial T

--- a/buildnode-kml.asd
+++ b/buildnode-kml.asd
@@ -1,20 +1,12 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :net.acceleration.buildnode.system)
-    (defpackage :net.acceleration.buildnode.system
-	(:use :common-lisp :asdf))))
-
-(in-package :net.acceleration.buildnode.system)
-
 (defsystem :buildnode-kml
   :description "Tool for building up an xml dom of an KML."
   :components
   ((:module :src
-	    :serial T
-	    :components
-	    ((:module :tags
-		      :serial T
-		      :components
-		      ((:file "kml"))))))
+    :serial T
+    :components
+    ((:module :tags
+      :serial T
+      :components ((:file "kml"))))))
   :depends-on (:buildnode))

--- a/buildnode-xhtml.asd
+++ b/buildnode-xhtml.asd
@@ -2,6 +2,7 @@
 
 (defsystem :buildnode-xhtml
   :description "Tool for building up an xml dom of an excel spreadsheet nicely."
+  :licence "BSD-3-Clause"
   :components
   ((:module :src
     :serial T

--- a/buildnode-xhtml.asd
+++ b/buildnode-xhtml.asd
@@ -1,20 +1,12 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :net.acceleration.buildnode.system)
-    (defpackage :net.acceleration.buildnode.system
-	(:use :common-lisp :asdf))))
-
-(in-package :net.acceleration.buildnode.system)
-
 (defsystem :buildnode-xhtml
   :description "Tool for building up an xml dom of an excel spreadsheet nicely."
   :components
   ((:module :src
-	    :serial T
-	    :components
-	    ((:module :tags
-		      :serial T
-		      :components
-		      ((:file "xhtml-tags"))))))
+    :serial T
+    :components
+    ((:module :tags
+      :serial T
+      :components ((:file "xhtml-tags"))))))
   :depends-on (:buildnode))

--- a/buildnode-xul.asd
+++ b/buildnode-xul.asd
@@ -2,6 +2,7 @@
 
 (defsystem :buildnode-xul
   :description "Tool for building up an xml dom of a Mozilla xul document"
+  :licence "BSD-3-Clause"
   :components
   ((:module :src
     :serial T

--- a/buildnode-xul.asd
+++ b/buildnode-xul.asd
@@ -1,20 +1,12 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :net.acceleration.buildnode.system)
-    (defpackage :net.acceleration.buildnode.system
-	(:use :common-lisp :asdf))))
-
-(in-package :net.acceleration.buildnode.system)
-
 (defsystem :buildnode-xul
   :description "Tool for building up an xml dom of a Mozilla xul document"
   :components
   ((:module :src
-	    :serial T
-	    :components
-	    ((:module :tags
-		      :serial T
-		      :components
-		      ((:file "xul-tags"))))))
+    :serial T
+    :components
+    ((:module :tags
+      :serial T
+      :components ((:file "xul-tags"))))))
   :depends-on (:buildnode))

--- a/buildnode.asd
+++ b/buildnode.asd
@@ -3,7 +3,7 @@
 (defsystem :buildnode
   :description "Tool for building up an xml dom nicely."
   :author "http://www.acceleration.net"
-  :licence "BSD"
+  :licence "BSD-3-Clause"
   :components
   ((:module :src
     :serial T
@@ -34,7 +34,7 @@
 (defsystem :buildnode/test
   :description ":buildnode/test: tests for buildnode library of code"
   :author "http://www.acceleration.net"
-  :licence "BSD"
+  :licence "BSD-3-Clause"
   :components
   ((:module :tests
     :serial t

--- a/buildnode.asd
+++ b/buildnode.asd
@@ -1,55 +1,48 @@
 ;; -*- lisp -*-
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless (find-package :net.acceleration.buildnode.system)
-    (defpackage :net.acceleration.buildnode.system
-	(:use :common-lisp :asdf))))
-
-(in-package :net.acceleration.buildnode.system)
-
 (defsystem :buildnode
   :description "Tool for building up an xml dom nicely."
   :author "http://www.acceleration.net"
   :licence "BSD"
   :components
   ((:module :src
-	    :serial T
-	    :components
-	    ((:file "packages")
-	     ;; should be removed once a patch doing the same thing makes its
-	     ;; way upstream
-	     (:file "dom-walker")
-	     (:file "buildnode")
-	     (:module :tags
-		      :serial T
-		      :components ((:file "tags" ))))))
-  :depends-on (:cxml :alexandria
-               :iterate :flexi-streams :split-sequence
-		     :swank ;; for setting tag-indentation
-		     :cl-interpol
-                     :collectors
-		     ;; TODO:
-		     ;; for html-generation - probably not a dependancy of the whole library
-		     :closure-html
-                     :cl-ppcre
-                     :symbol-munger
-		     ))
+    :serial T
+    :components
+    ((:file "packages")
+     ;; should be removed once a patch doing the same thing makes its
+     ;; way upstream
+     (:file "dom-walker")
+     (:file "buildnode")
+     (:module :tags
+      :serial T
+      :components ((:file "tags" ))))))
+  :depends-on (:cxml
+               :alexandria
+               :iterate
+               :flexi-streams
+               :split-sequence
+               :swank ;; for setting tag-indentation
+               :cl-interpol
+               :collectors
+               ;; TODO:
+               ;; for html-generation - probably not a dependancy of the whole library
+               :closure-html
+               :cl-ppcre
+               :symbol-munger)
+  :in-order-to ((test-op (test-op :buildnode/test))))
 
-(defsystem :buildnode-test
-  :description ":buildnode-test: tests for buildnode library of code"
+(defsystem :buildnode/test
+  :description ":buildnode/test: tests for buildnode library of code"
   :author "http://www.acceleration.net"
   :licence "BSD"
   :components
   ((:module :tests
-	    :serial t
-	    :components ((:file "setup")
-			 (:file "basic-tests"))))
-  :depends-on (:buildnode :buildnode-xhtml :lisp-unit2))
-
-(defmethod asdf:perform ((o asdf:test-op) (c (eql (find-system :buildnode))))
-  (asdf:load-system :buildnode-test)
-  (let ((*package* (find-package :buildnode-test)))
-    (eval (read-from-string "(run-tests)"))))
+    :serial t
+    :components ((:file "setup")
+                 (:file "basic-tests"))))
+  :depends-on (:buildnode :buildnode-xhtml :lisp-unit2)
+  :perform (test-op (o c)
+             (symbol-call :buildnode-test :run-tests)))
 
 ;; Copyright (c) 2011 Russ Tyndall , Acceleration.net http://www.acceleration.net
 ;; All rights reserved.


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)

(Bonus: visual clean-ups)